### PR TITLE
Swap SRC and LDFLAGS Variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CC = gcc
 SRC = main.c
 
 all:
-	$(CC) $(CFLAGS) $(LDFLAGS) $(SRC) -o $(BIN)
+	$(CC) $(CFLAGS) $(SRC) $(LDFLAGS) -o $(BIN)
 
 run:
 	./$(BIN)


### PR DESCRIPTION
Libraries should come after source files with GCC. GCC is picky about the ordering of libraries and source files. On my system (Ubuntu x86-64) this fixed the linker errors that I was getting before, it also shouldn't cause errors on other platforms.